### PR TITLE
Ubuntu 16 Xenial Support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,5 @@ galaxy_info:
     - trusty
     - xenial
 dependencies:
-  - { role: 'geerlingguy.repo-epel', when: ansible_distribution == "CentOS" }
+  - role: 'geerlingguy.repo-epel'
+    when: ansible_distribution == "CentOS"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,5 +11,6 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
 dependencies:
   - { role: 'geerlingguy.repo-epel', when: ansible_distribution == "CentOS" }

--- a/tasks/Ubuntu14+16.yml
+++ b/tasks/Ubuntu14+16.yml
@@ -10,13 +10,13 @@
 
 - name: Add INDIGO-base APT repository
   apt_repository:
-    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/{{ indigo_release }}/ubuntu/ trusty main third-party"
+    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/{{ indigo_release }}/ubuntu/ {{ ansible_distribution_release }} main third-party"
     state: present
     filename: indigo
 
 - name: Add INDIGO-updates APT repository
   apt_repository:
-    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/{{ indigo_release }}/ubuntu/ trusty-updates main third-party"
+    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/{{ indigo_release }}/ubuntu/ {{ ansible_distribution_release }}-updates main third-party"
     state: present
     filename: indigo
 

--- a/tasks/Ubuntu14.yml
+++ b/tasks/Ubuntu14.yml
@@ -16,7 +16,7 @@
 
 - name: Add INDIGO-updates APT repository
   apt_repository:
-    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/1/ubuntu/ trusty-updates main third-party"
+    repo: "deb [arch=amd64] http://repo.indigo-datacloud.eu/repository/indigo/{{ indigo_release }}/ubuntu/ trusty-updates main third-party"
     state: present
     filename: indigo
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,6 @@
   include: CentOS7.yml 
   when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7")
 
-- name: Ubuntu14 specific tasks
-  include: Ubuntu14.yml 
-  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == "14")
+- name: Ubuntu14/16 specific tasks
+  include: Ubuntu14+16.yml
+  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == "14" or ansible_distribution_major_version == "16")


### PR DESCRIPTION
I added support for _Ubuntu 16_, which is required for the _INDIGO-2_ release. 

I also fixed a small bug which statically referenced the _INDIGO-1_ repo instead of using the `{{ indigo_release }}` role variable.